### PR TITLE
Check the state as soon as waitForState is called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ const createWaitForState = () => {
   let store;
 
   const waitForState = predicate => new Promise(resolve => {
+    if (predicate(store.getState())) {
+      resolve();
+      return;
+    }
+
     const unsubscribe = store.subscribe(() => {
       if (predicate(store.getState())) {
         unsubscribe();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -40,3 +40,32 @@ test('wait for state resolves when predicate returns true', () => {
 
   expect(mock).toHaveBeenCalled();
 });
+
+test('wait for state resolves in next tick if predicate already returns true', () => {
+  const state = {
+    isValueWeWant: true,
+  };
+
+  const mock = jest.fn();
+  const unsubscribeMock = jest.fn();
+  const subscribeMock = jest.fn(() => unsubscribeMock);
+  const getStateMock = jest.fn(() => state);
+  const predicate = jest.fn(s => s.isValueWeWant);
+
+  const STORE = {
+    subscribe: subscribeMock,
+    getState: getStateMock,
+  };
+
+  const { waitForState, setStore } = createWaitForState();
+
+  setStore(STORE);
+  waitForState(predicate).then(mock);
+
+  expect(subscribeMock).not.toHaveBeenCalled();
+  expect(predicate).toHaveBeenCalledWith(state);
+
+  jest.runAllTimers();
+
+  expect(mock).toHaveBeenCalled();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.23.0, babel-core@^6.23.1:
+babel-core@^6.0.0, babel-core@^6.23.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.23.1.tgz#c143cb621bb2f621710c220c5d579d15b8a442df"
   dependencies:
@@ -343,15 +343,6 @@ babel-jest@^19.0.0:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^19.0.0"
-
-babel-loader@^6.3.2:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.3.2.tgz#18de4566385578c1b4f8ffe6cbc668f5e2a5ef03"
-  dependencies:
-    find-cache-dir "^0.1.1"
-    loader-utils "^0.2.16"
-    mkdirp "^0.5.1"
-    object-assign "^4.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -939,10 +930,6 @@ commander@^2.8.1, commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commondir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1488,14 +1475,6 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
-
-find-cache-dir@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
-  dependencies:
-    commondir "^1.0.1"
-    mkdirp "^0.5.1"
-    pkg-dir "^1.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
This fixes #1, a bug where we failed to check the current state of the store, and thus would block until the store changes at some point in the future.

We now check the state immediately, and resolve the promise if it is the way we want it to be.